### PR TITLE
Implement shift space for underscore

### DIFF
--- a/keyboards/moonlander/keymaps/warpotato/dances_user.c
+++ b/keyboards/moonlander/keymaps/warpotato/dances_user.c
@@ -397,7 +397,7 @@ void on_dance_space(tap_dance_state_t *state, void *user_data);
 
 void on_dance_space(tap_dance_state_t* state, void* user_data) {
     if(get_mods() & MOD_MASK_SHIFT) {
-        tap_code16(KC_UNDS);
+        tap_code16(S(KC_MINUS));
     } else {
         tap_code16(KC_SPACE);
     }

--- a/keyboards/moonlander/keymaps/warpotato/dances_user.c
+++ b/keyboards/moonlander/keymaps/warpotato/dances_user.c
@@ -384,7 +384,7 @@ void on_dance_ra(tap_dance_state_t* state, void* user_data) {
 void dance_ra_finished(tap_dance_state_t* state, void* user_data) {
     mod_charswap_dance_finished(
         &(dance_state[DNC_RIGHT]), state, KC_RIGHT, KC_RIGHT, os_bksp_mod
-    );
+    );    
 }
 
 void dance_ra_reset(tap_dance_state_t* state, void* user_data) {
@@ -394,46 +394,13 @@ void dance_ra_reset(tap_dance_state_t* state, void* user_data) {
 }
 
 void on_dance_space(tap_dance_state_t *state, void *user_data);
-void dance_space_finished(tap_dance_state_t *state, void *user_data);
-void dance_space_reset(tap_dance_state_t *state, void *user_data);
 
 void on_dance_space(tap_dance_state_t* state, void* user_data) {
-    if(state->count == 3) {
+    if(get_mods() & MOD_MASK_SHIFT) {
         tap_code16(KC_UNDS);
-        tap_code16(KC_UNDS);
-        tap_code16(KC_UNDS);
+    } else {
+        tap_code16(KC_SPACE);
     }
-    if(state->count > 3) {
-        tap_code16(S(KC_UNDS));
-    }
-}
-
-void dance_space_finished(tap_dance_state_t *state, void *user_data) {
-    dance_state[DNC_SPACE].step = dance_step(state);
-    switch (dance_state[DNC_SPACE].step) {
-        case SINGLE_TAP:
-            register_code16(KC_UNDS);
-            break;
-        case SINGLE_HOLD: layer_on(NAV_LAYOUT); break;
-        case DOUBLE_TAP:
-        case DOUBLE_SINGLE_TAP:
-            tap_code16(KC_UNDS);
-            register_code16(KC_UNDS);
-    }
-}
-
-void dance_space_reset(tap_dance_state_t *state, void *user_data) {
-    wait_ms(10);
-    switch (dance_state[DNC_SPACE].step) {
-        case SINGLE_TAP:
-            unregister_code16(KC_UNDS);
-            break;
-        case SINGLE_HOLD: layer_off(NAV_LAYOUT); break;
-        case DOUBLE_TAP:
-        case DOUBLE_SINGLE_TAP:
-            unregister_code16(KC_UNDS);
-    }
-    dance_state[DNC_RH_FNSWAP].step = 0;
 }
 
 
@@ -448,7 +415,7 @@ tap_dance_action_t tap_dance_actions[] = {
         [DNC_CURLY] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, curlyswap_finished, curlyswap_reset),
         [DNC_SQUARE] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, squareswap_finished, squareswap_reset),
         [DNC_BOOTLOADER] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, dance_bootloader_finished, dance_bootloader_reset),
-        [DNC_SPACE] = ACTION_TAP_DANCE_FN_ADVANCED(on_dance_space, dance_space_finished, dance_space_reset),
+        [DNC_SPACE] = ACTION_TAP_DANCE_FN_ADVANCED(on_dance_space, NULL, NULL),
         [DNC_RH_FNSWAP] = ACTION_TAP_DANCE_FN_ADVANCED(on_dance_rh, dance_rh_fnswap_finished, dance_rh_fnswap_reset),
         [DNC_BACKSPACE] = ACTION_TAP_DANCE_FN_ADVANCED(on_dance_backspace, dance_backspace_finished, dance_backspace_reset),
         [DNC_LEFT] = ACTION_TAP_DANCE_FN_ADVANCED(on_dance_la, dance_la_finished, dance_la_reset),

--- a/keyboards/moonlander/keymaps/warpotato/layout_user.h
+++ b/keyboards/moonlander/keymaps/warpotato/layout_user.h
@@ -17,8 +17,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_GRAVE,       KC_Q,           KC_W,           KC_E,          KC_R,           KC_T,                KC_Y,                           KC_EQUAL,   KC_U,        KC_I,                  KC_O,        KC_P,    KC_BSLS,        KC_VOLU,
     KC_CAPS_LOCK,   KC_A,           KC_S,           KC_D,          TD(DNC_FIND),   KC_G,                KC_H,                           KC_MINUS,   KC_J,        KC_K,                  KC_L,        KC_SCLN, KC_QUOTE,       KC_VOLD,
     SC_LSPO,        KC_Z,           TD(DNC_XCUT),   TD(DNC_COPY),  TD(DNC_CPS),    KC_B,                                                            KC_N,        KC_M,                  KC_COMMA,    KC_DOT,  KC_SLASH,       SC_RSPC,
-    KC_TRANSPARENT, KC_TRANSPARENT, TD(DNC_RTN_L0), TD(DNC_SPACE), LT(FKEYS_LAYOUT, KC_TAB),            TD(DNC_BACKSPACE),              TT(NUMKEYS_LAYOUT),      TD(DNC_RH_FNSWAP),     KC_LBRC,     KC_RBRC, KC_TRANSPARENT, KC_LGUI,
-                                                                   KC_SPACE,  MT(MOD_LCTL, KC_ENTER),   TD(DNC_SUPER_ALT_TAB),          MT(MOD_LALT, KC_QUOTE),  MT(MOD_LCTL, KC_DOT),  MT(MOD_LSFT, KC_EQUAL)
+    KC_TRANSPARENT, KC_TRANSPARENT, TD(DNC_RTN_L0), TT(NAV_LAYOUT), LT(FKEYS_LAYOUT, KC_TAB),            TD(DNC_BACKSPACE),              TT(NUMKEYS_LAYOUT),      TD(DNC_RH_FNSWAP),     KC_LBRC,     KC_RBRC, KC_TRANSPARENT, KC_LGUI,
+                                                                   TD(DNC_SPACE),  MT(MOD_LCTL, KC_ENTER),   TD(DNC_SUPER_ALT_TAB),          MT(MOD_LALT, KC_QUOTE),  MT(MOD_LCTL, KC_DOT),  MT(MOD_LSFT, KC_EQUAL)
   ),
   [OS_MAC_LAYOUT] = LAYOUT_moonlander(
       // minor modifications for mac os; most are handled via generic tapdance defs,


### PR DESCRIPTION
Lessons learned: `tap_code16` and register_code16` require use of the shift modifier.